### PR TITLE
Remove Dynamic Target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,6 @@ let package = Package(
     products: [
         .library(
             name: "PocketSVG",
-            type: .dynamic,
             targets: ["PocketSVG"])
     ],
     dependencies: [


### PR DESCRIPTION
Removing the dynamic target type allows this to compile correctly when compiling for catalyst.